### PR TITLE
Added support for default options for Pathfinder 2e game system

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -15,7 +15,7 @@ const DEFAULT = {
  */
 const setDefaults = () => {
   // Default to system values
-  if (game.system.id === 'dnd5e') {
+  if (game.system.id === 'dnd5e' || game.system.id === 'pf2e') {
     DEFAULT.HITPOINTS_ATTRIBUTE = 'attributes.hp.value';
     DEFAULT.MAX_HITPOINTS_ATTRIBUTE = 'attributes.hp.max';
     DEFAULT.TEMP_HITPOINTS_ATTRIBUTE = 'attributes.hp.temp';


### PR DESCRIPTION
The pf2e compendium extends actor sheets for PCs and NPCs from the dnd5e system. Merging this change will make your module compatible with pf2e as well.