### PR TITLE
Update token-health.js

### DIFF
--- a/token-health.js
+++ b/token-health.js
@@ -46,7 +46,7 @@ const applyDamage = async (html, isDamage) => {
       dt = damage > 0 ? Math.min(tmp, damage) : 0;
 
     const newTempHP = tmp - dt;
-    const newHP = Math.clamped(hp - (damage - dt), 0, max);
+    const newHP = Math.max(hp - (damage - dt), max);
 
     const updates = {_id: actor.id, isToken: actor.isToken};
 


### PR DESCRIPTION
I think this might solve issue #11 that I also experienced, in fact, I can set negative hp from the actor sheet, but can't do the same thing using the module while dealing damage. Negative hp do not exist in DnD 5e, but they exist in other game systems like Pathfinder 1e.